### PR TITLE
Fix/fix tab name when multi stage pipeline

### DIFF
--- a/src/tabContent.tsx
+++ b/src/tabContent.tsx
@@ -68,7 +68,7 @@ abstract class AttachmentClient {
     console.log(responseText)
     return responseText
   }
-  
+
 }
 
 class BuildAttachmentClient extends AttachmentClient {
@@ -136,7 +136,7 @@ export default class TaskAttachmentPanel extends React.Component<TaskAttachmentP
               {tabs}
             </TabBar>
           : null }
-          <Observer selectedTabId={this.selectedTabId} tabContents={this.tabContents}>            
+          <Observer selectedTabId={this.selectedTabId} tabContents={this.tabContents}>
             {(props: { selectedTabId: string }) => {
               if ( this.tabContents.get(props.selectedTabId) === this.tabInitialContent) {
                 this.props.attachmentClient.getAttachmentContent(props.selectedTabId).then((content) => {

--- a/src/tabContent.tsx
+++ b/src/tabContent.tsx
@@ -121,7 +121,7 @@ export default class TaskAttachmentPanel extends React.Component<TaskAttachmentP
       for (const attachment of attachments) {
         const metadata = attachment.name.split('.')
         // Conditionally add counter for multistage pipeline
-        const name = metadata[2] !== '__default' ? `${metadata[2]} #${metadata[3]}` : metadata[0]
+        const name = metadata[2] !== '__default' ? `${metadata[0]} #${metadata[3]}` : metadata[0]
 
         tabs.push(<Tab name={name} id={attachment.name} key={attachment.name} url={attachment._links.self.href}/>)
         this.tabContents.add(attachment.name, this.tabInitialContent)


### PR DESCRIPTION
Fixes github issue #8, by implementing @hoani [suggested fix](https://github.com/JakubRumpca/azure-pipeline-html-report/issues/8#issuecomment-939551310). 

Before:
![githubIssue8](https://github.com/JakubRumpca/azure-pipeline-html-report/assets/2846726/fdf694ae-f857-402a-bac8-40ef4929e25a)

After:
![githubIssue8-fixed](https://github.com/JakubRumpca/azure-pipeline-html-report/assets/2846726/fa660d92-8240-4cc9-a328-f09ff5435cd7)

The Azure DevOps extension has been [published here](https://marketplace.visualstudio.com/items?itemName=awardedsolutions.azure-pipelines-html-report-awardedsolutions) and will be maintained until @JakubRumpca merges this PR or another suitable fix.